### PR TITLE
Release/2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
 install: pip install .
 script: python setup.py test
 deploy:
-  on:
-    branch: master
+- on:
+    python: '3.6'
+    tags: true
   provider: pypi
   distributions: 'bdist_wheel sdist'
   user: efl_phx

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -55,24 +55,24 @@ class ClassRegistryInstanceCache(object):
         """
         Returns the cached instance associated with the specified key.
         """
-        cache_key = self.gen_cache_key(key)
+        instance_key = self.get_instance_key(key)
 
-        if cache_key not in self._cache:
-            lookup_key = self.gen_lookup_key(key)
+        if instance_key not in self._cache:
+            class_key = self.get_class_key(key)
 
             # Map lookup keys to cache keys so that we can iterate over
             # them in the correct order.
             # :py:meth:`__iter__`
-            self._key_map[lookup_key].append(cache_key)
+            self._key_map[class_key].append(instance_key)
 
-            self._cache[cache_key] =\
+            self._cache[instance_key] =\
                 self._registry.get(
-                    lookup_key,
+                    class_key,
                     *self._template_args,
                     **self._template_kwargs
                 )
 
-        return self._cache[cache_key]
+        return self._cache[instance_key]
 
     def __iter__(self):
         # type: () -> Generator[Any]
@@ -97,7 +97,7 @@ class ClassRegistryInstanceCache(object):
         for key in iterkeys(self._registry):
             self.__getitem__(key)
 
-    def gen_cache_key(self, key):
+    def get_instance_key(self, key):
         # type: (Any) -> Hashable
         """
         Generates a key that can be used to store/lookup values in the
@@ -106,9 +106,9 @@ class ClassRegistryInstanceCache(object):
         :param key:
             Value provided to :py:meth:`__getitem__`.
         """
-        return self.gen_lookup_key(key)
+        return self.get_class_key(key)
 
-    def gen_lookup_key(self, key):
+    def get_class_key(self, key):
         # type: (Any) -> Hashable
         """
         Generates a key that can be used to store/lookup values in the

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -28,7 +28,7 @@ class ClassRegistryInstanceCache(object):
     both the ClassRegistry and the ClassRegistryInstanceCache.
     """
     def __init__(self, class_registry, *args, **kwargs):
-        # type: (ClassRegistry, ...) -> None
+        # type: (ClassRegistry, *Any, **Any) -> None
         """
         :param class_registry:
             The wrapped ClassRegistry.

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -75,7 +75,7 @@ class ClassRegistryInstanceCache(object):
         return self._cache[cache_key]
 
     def __iter__(self):
-        # type: () -> Generator[Hashable]
+        # type: () -> Generator[Any]
         """
         Returns a generator for iterating over cached instances, using
         the wrapped registry to determine sort order.

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+from typing import Any
+
 from six import iteritems
 
 from class_registry.registry import MutableRegistry, RegistryKeyError
@@ -25,7 +27,7 @@ class RegistryPatcher(object):
         pass
 
     def __init__(self, registry, *args, **kwargs):
-        # type: (MutableRegistry, ...) -> None
+        # type: (MutableRegistry, *Any, **Any) -> None
         """
         :param registry:
             A :py:class:`MutableRegistry` instance to patch.

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -112,7 +112,7 @@ class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
 
     @staticmethod
     def create_instance(class_, *args, **kwargs):
-        # type: (type, ...) -> Any
+        # type: (type, *Any, **Any) -> Any
         """
         Prepares the return value for :py:meth:`get`.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Factory+Registry pattern for Python classes.',
     url = 'https://class-registry.readthedocs.io/',
 
-    version = '2.0.3',
+    version = '2.1.0',
 
     packages = ['class_registry'],
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Factory+Registry pattern for Python classes.',
     url = 'https://class-registry.readthedocs.io/',
 
-    version = '2.0.2',
+    version = '2.0.3',
 
     packages = ['class_registry'],
 


### PR DESCRIPTION
# Class Registry v2.1.0
**⚠️ This version contains changes that are not backwards-compatible with Class Registry v2.0.2.  Please review the Backwards-Incompatible Changes before upgrading! ⚠️**

## Backwards-Incompatible Changes
* Renamed methods in `ClassRegistryInstanceCache` to make it easier to understand what they are used for:
    * `gen_cache_key` => `get_instance_key` (this method is used to determine the lookup key for cached instances)
    * `gen_lookup_key` => `get_class_key` (this method is used to determine the lookup key for registered classes)

## Other Changes
* Fixed incorrect PEP-484 type hints.
* Travis CI now builds universal wheels.
* Travis CI now only deploys tagged releases to PyPI.