### PR TITLE
Release/2.1.1

### DIFF
--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -34,6 +34,20 @@ class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
     """
     Base functionality for registries.
     """
+    def __contains__(self, key):
+        """
+        Returns whether the specified key is registered.
+        """
+        try:
+            # Use :py:meth:`get_class` instead of :py:meth:`__getitem__`
+            # in case the registered class' initializer requires
+            # arguments.
+            self.get_class(key)
+        except RegistryKeyError:
+            return False
+        else:
+            return True
+
     def __dir__(self):
         return list(self.keys())
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Factory+Registry pattern for Python classes.',
     url = 'https://class-registry.readthedocs.io/',
 
-    version = '2.1.0',
+    version = '2.1.1',
 
     packages = ['class_registry'],
 

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from pkg_resources import iter_entry_points, working_set
 
 from class_registry import EntryPointClassRegistry, RegistryKeyError
-from test import Bulbasaur, Charmander, Mew, Squirtle, PokemonFactory
+from test import Bulbasaur, Charmander, Mew, PokemonFactory, Squirtle
 
 
 def setUpModule():

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -52,7 +52,7 @@ class EntryPointClassRegistryTestCase(TestCase):
 
     def test_branding(self):
         """
-        Configuring the registry to "brand" each instance with its
+        Configuring the registry to "brand" each class/instance with its
         corresponding key.
         """
         registry = EntryPointClassRegistry('pokemon', attr_name='poke_type')

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from pkg_resources import iter_entry_points, working_set
 
 from class_registry import EntryPointClassRegistry, RegistryKeyError
-from test import Bulbasaur, Charmander, Mew, Squirtle
+from test import Bulbasaur, Charmander, Mew, Squirtle, PokemonFactory
 
 
 def setUpModule():
@@ -52,16 +52,33 @@ class EntryPointClassRegistryTestCase(TestCase):
 
     def test_branding(self):
         """
-        Configuring the registry to "brand" each class with its
+        Configuring the registry to "brand" each instance with its
         corresponding key.
         """
         registry = EntryPointClassRegistry('pokemon', attr_name='poke_type')
+        try:
+            # Branding is applied immediately to each registered class.
+            self.assertEqual(getattr(Charmander, 'poke_type'), 'fire')
+            self.assertEqual(getattr(Squirtle, 'poke_type'), 'water')
 
-        fire_type = registry.get_class('fire')
-        self.assertEqual(getattr(fire_type, 'poke_type'), 'fire')
+            # Registered functions and methods can't be branded this
+            # way...
+            self.assertFalse(
+                hasattr(PokemonFactory.create_psychic_pokemon, 'poke_type'),
+            )
 
-        water = registry['water']
-        self.assertEqual(getattr(water, 'poke_type'), 'water')
+            # ... but we can still brand individual instances.
+            self.assertEqual(registry['fire'].poke_type, 'fire')
+            self.assertEqual(registry['water'].poke_type, 'water')
+            self.assertEqual(registry['psychic'].poke_type, 'psychic')
+        finally:
+            # Clean up after ourselves.
+            for cls in registry.values():
+                if isinstance(cls, type):
+                    try:
+                        delattr(cls, 'poke_type')
+                    except AttributeError:
+                        pass
 
     def test_len(self):
         """

--- a/test/registry_test.py
+++ b/test/registry_test.py
@@ -192,6 +192,22 @@ class ClassRegistryTestCase(TestCase):
         self.assertIsInstance(poke, Charmeleon)
         self.assertEqual(poke.name, 'trogdor')
 
+    def test_contains_when_class_init_requires_arguments(self):
+        """
+        Special case when checking if a class is registered, and that class'
+        initializer requires arguments.
+        """
+        registry = ClassRegistry(attr_name='element')
+
+        @registry.register
+        class Butterfree(Pokemon):
+            element = 'bug'
+
+            def __init__(self, name):
+                super(Butterfree, self).__init__(name)
+
+        self.assertTrue('bug' in registry)
+
 
 class SortedClassRegistryTestCase(TestCase):
     def test_sort_key(self):


### PR DESCRIPTION
# Class Registry v2.1.1
- Calling `__contains__` no longer raises an exception if the corresponding class' initalizer requires arguments.
- `EntryPointClassRegistry` now applies branding aggressively:
    - Branding is applied immediately upon initializing the registry.
    - Branding is applied to both classes and instances (important for entry points that reference functions/methods).