### PR TITLE
Release/2.1.2

### DIFF
--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -49,17 +49,6 @@ class EntryPointClassRegistry(BaseRegistry):
         if self.attr_name:
             self._get_cache()
 
-    def __getitem__(self, key):
-        instance = super(EntryPointClassRegistry, self).__getitem__(key)
-
-        if self.attr_name:
-            # Apply branding to the instance explicitly.
-            # This is particularly important if the corresponding entry
-            # point references a function or method.
-            setattr(instance, self.attr_name, key)
-
-        return instance
-
     def __len__(self):
         return len(self._get_cache())
 
@@ -68,6 +57,18 @@ class EntryPointClassRegistry(BaseRegistry):
             group   = self.group,
             type    = type(self).__name__,
         )
+
+    def get(self, key, *args, **kwargs):
+        instance =\
+            super(EntryPointClassRegistry, self).get(key, *args, **kwargs)
+
+        if self.attr_name:
+            # Apply branding to the instance explicitly.
+            # This is particularly important if the corresponding entry
+            # point references a function or method.
+            setattr(instance, self.attr_name, key)
+
+        return instance
 
     def get_class(self, key):
         try:

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -226,7 +226,7 @@ class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry, MutableMapping)):
     def __delitem__(self, key):
         # type: (Hashable) -> None
         """
-        Provides alternate syntax for unregistering a class.
+        Provides alternate syntax for un-registering a class.
         """
         self._unregister(key)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Factory+Registry pattern for Python classes.',
     url = 'https://class-registry.readthedocs.io/',
 
-    version = '2.1.1',
+    version = '2.1.2',
 
     packages = ['class_registry'],
 

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -61,16 +61,19 @@ class EntryPointClassRegistryTestCase(TestCase):
             self.assertEqual(getattr(Charmander, 'poke_type'), 'fire')
             self.assertEqual(getattr(Squirtle, 'poke_type'), 'water')
 
+            # Instances, too!
+            self.assertEqual(registry['fire'].poke_type, 'fire')
+            self.assertEqual(registry.get('water', 'phil').poke_type, 'water')
+
             # Registered functions and methods can't be branded this
-            # way...
+            # way, though...
             self.assertFalse(
                 hasattr(PokemonFactory.create_psychic_pokemon, 'poke_type'),
             )
 
-            # ... but we can still brand individual instances.
-            self.assertEqual(registry['fire'].poke_type, 'fire')
-            self.assertEqual(registry['water'].poke_type, 'water')
+            # ... but we can brand the resulting instances.
             self.assertEqual(registry['psychic'].poke_type, 'psychic')
+            self.assertEqual(registry.get('psychic').poke_type, 'psychic')
         finally:
             # Clean up after ourselves.
             for cls in registry.values():


### PR DESCRIPTION
# Class Registry v2.1.2
- Fixed an issue preventing `EntryPointClassRegistry.get()` from applying branding.