### PR TITLE
Install 'typing' for python < 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires = [
         'six',
-        'typing; python_version < "3.0"',
+        'typing; python_version < "3.5"',
     ],
 
     test_suite    = 'test',


### PR DESCRIPTION
This will enable support for python 3.4