### PR TITLE
Drop legacy Python 2.7 and add support for Python 3.7

### DIFF
--- a/class_registry/__init__.py
+++ b/class_registry/__init__.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .registry import *
 from .auto_register import *
 from .cache import *

--- a/class_registry/auto_register.py
+++ b/class_registry/auto_register.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta
 from inspect import isabstract as is_abstract
 

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, division, print_function, \
 from collections import defaultdict
 from typing import Any, Dict, Generator, Hashable
 
-from six import iterkeys
-
 from class_registry import ClassRegistry
 
 __all__ = [
@@ -82,7 +80,7 @@ class ClassRegistryInstanceCache(object):
 
         If a key has not been accessed yet, it will not be included.
         """
-        for lookup_key in iterkeys(self._registry):
+        for lookup_key in self._registry.keys():
             for cache_key in self._key_map[lookup_key]:
                 yield self._cache[cache_key]
 
@@ -94,7 +92,7 @@ class ClassRegistryInstanceCache(object):
         Note that this method does not account for any classes that may
         be added to the wrapped ClassRegistry in the future.
         """
-        for key in iterkeys(self._registry):
+        for key in self._registry.keys():
             self.__getitem__(key)
 
     def get_instance_key(self, key):

--- a/class_registry/cache.py
+++ b/class_registry/cache.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from collections import defaultdict
 from typing import Any, Dict, Generator, Hashable
 

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, \
 from typing import Dict, Optional, Text
 
 from pkg_resources import iter_entry_points
-from six import iteritems
 
 from class_registry import BaseRegistry
 
@@ -79,7 +78,7 @@ class EntryPointClassRegistry(BaseRegistry):
         return cls
 
     def items(self):
-        return iteritems(self._get_cache())
+        return self._get_cache().items()
 
     def refresh(self):
         """

--- a/class_registry/entry_points.py
+++ b/class_registry/entry_points.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Dict, Optional, Text
 
 from pkg_resources import iter_entry_points

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -4,8 +4,6 @@ from __future__ import absolute_import, division, print_function, \
 
 from typing import Any
 
-from six import iteritems
-
 from class_registry.registry import MutableRegistry, RegistryKeyError
 
 __all__ = [
@@ -75,7 +73,7 @@ class RegistryPatcher(object):
         }
 
         # Patch values.
-        for key, value in iteritems(self._new_values):
+        for key, value in self._new_values.items():
             # Remove the existing value first (prevents issues if the
             # registry has ``unique=True``).
             self._del_value(key)
@@ -88,7 +86,7 @@ class RegistryPatcher(object):
         Restores previous settings.
         """
         # Restore previous settings.
-        for key, value in iteritems(self._prev_values):
+        for key, value in self._prev_values.items():
             # Remove the existing value first (prevents issues if the
             # registry has ``unique=True``).
             self._del_value(key)

--- a/class_registry/patcher.py
+++ b/class_registry/patcher.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Any
 
 from class_registry.registry import MutableRegistry, RegistryKeyError

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -9,7 +9,6 @@ from inspect import isclass as is_class
 from typing import Any, Callable, Generator, Hashable, Iterator, \
     Mapping, MutableMapping, Optional, Text, Tuple, Union
 
-from six import PY2, iteritems, with_metaclass
 
 __all__ = [
     'BaseRegistry',
@@ -30,7 +29,7 @@ class RegistryKeyError(KeyError):
     pass
 
 
-class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
+class BaseRegistry(Mapping, metaclass=ABCMeta):
     """
     Base functionality for registries.
     """
@@ -182,32 +181,8 @@ class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
         for item in self.items():
             yield item[1]
 
-    # Add some compatibility aliases to make class registries behave
-    # more like dicts in Python 2.
-    if PY2:
-        def iteritems(self):
-            """
-            Included for compatibility with :py:data:`six.iteritems`.
-            Do not invoke directly!
-            """
-            return self.items()
 
-        def iterkeys(self):
-            """
-            Included for compatibility with :py:data:`six.iterkeys`.
-            Do not invoke directly!
-            """
-            return self.keys()
-
-        def itervalues(self):
-            """
-            Included for compatibility with :py:data:`six.itervalues`.
-            Do not invoke directly!
-            """
-            return self.values()
-
-
-class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry, MutableMapping)):
+class MutableRegistry(BaseRegistry, MutableMapping, metaclass=ABCMeta):
     """
     Extends :py:class:`BaseRegistry` with methods that can be used to
     modify the registered classes.
@@ -373,7 +348,7 @@ class ClassRegistry(MutableRegistry):
         Iterates over all registered classes, in the order they were
         added.
         """
-        return iteritems(self._registry)
+        return self._registry.items()
 
     def _register(self, key, class_):
         # type: (Hashable, type) -> None
@@ -457,9 +432,9 @@ class SortedClassRegistry(ClassRegistry):
     def items(self):
         # type: () -> Iterator[Tuple[Hashable, type]]
         return sorted(
-            iteritems(self._registry),
-                key     = self._sort_key,
-                reverse = self.reverse,
+            self._registry.items(),
+            key=self._sort_key,
+            reverse=self.reverse,
         )
 
     @staticmethod

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from collections import OrderedDict
 from functools import cmp_to_key

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     long_description = long_description,
 
     install_requires = [
-        'six',
         'typing; python_version < "3.0"',
     ],
 
@@ -44,11 +43,10 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 
 class Pokemon(object):
     """

--- a/test/auto_register_test.py
+++ b/test/auto_register_test.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import, division, print_function, \
 from abc import ABCMeta, abstractmethod as abstract_method
 from unittest import TestCase
 
-from six import with_metaclass
-
 from class_registry import AutoRegister, ClassRegistry
 
 
@@ -19,7 +17,7 @@ class AutoRegisterTestCase(TestCase):
 
         # Note that we declare :py:func:`AutoRegister` as the metaclass
         # for our base class.
-        class BasePokemon(with_metaclass(AutoRegister(registry))):
+        class BasePokemon(metaclass=AutoRegister(registry)):
             """
             Abstract base class; will not get registered.
             """
@@ -38,7 +36,7 @@ class AutoRegisterTestCase(TestCase):
                 return ['sand veil']
 
         # noinspection PyClassHasNoInit
-        class BaseEvolvingPokemon(with_metaclass(ABCMeta, BasePokemon)):
+        class BaseEvolvingPokemon(BasePokemon, metaclass=ABCMeta):
             """
             Abstract subclass; will not get registered.
             """
@@ -77,7 +75,7 @@ class AutoRegisterTestCase(TestCase):
         """
         registry = ClassRegistry(attr_name='element')
 
-        class FightingPokemon(with_metaclass(AutoRegister(registry))):
+        class FightingPokemon(metaclass=AutoRegister(registry)):
             element = 'fighting'
 
         self.assertListEqual(

--- a/test/auto_register_test.py
+++ b/test/auto_register_test.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from unittest import TestCase
 

--- a/test/cache_test.py
+++ b/test/cache_test.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 from class_registry.registry import ClassRegistry

--- a/test/entry_points_test.py
+++ b/test/entry_points_test.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from os.path import dirname
 from unittest import TestCase
 

--- a/test/patcher_test.py
+++ b/test/patcher_test.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 from class_registry.patcher import RegistryPatcher

--- a/test/registry_test.py
+++ b/test/registry_test.py
@@ -1,7 +1,4 @@
 # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from functools import cmp_to_key
 from unittest import TestCase
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py35, py36, py37
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Not actually expecting this to be merged but just like to raise awareness and maybe receive feedback.

We are in the works of updating our Python from 3.6 to 3.7 and class-registry failed violently with
```
...
    import class_registry
../../github/class-registry/class_registry/__init__.py:5: in <module>
    from .registry import *
../../github/class-registry/class_registry/registry.py:33: in <module>
    class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
../../github/six/six.py:884: in __call__
    return self.meta(name, self.bases, d)
../../../.virtualenvs/py37/lib/python3.7/abc.py:127: in __new__
    cls = super().__new__(mcls, name, bases, namespace, **kwargs)
E   TypeError: type() doesn't support MRO entry resolution; use types.new_class()
```
I googled around a bit but only found https://bugs.python.org/issue33188 that did not help me understand the issue. As a solution for us we choose to fork this repo and remove legacy Python support.