### PR TITLE
Fix error when running under Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
+  - '3.7'
 
 install:
   - pip install .
@@ -15,7 +16,7 @@ script:
 
 deploy:
   - on:
-      python: '3.6'
+      python: '3.7'
       tags: true
     provider: pypi
     distributions: 'bdist_wheel sdist'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - '2.7'

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ For more advanced usage, check out the documentation on `ReadTheDocs`_!
 Requirements
 ------------
 
-ClassRegistry is compatible with Python versions 3.6, 3.5 and 2.7.
+ClassRegistry is compatible with Python versions 3.7, 3.6, 3.5 and 2.7.
 
 
 Installation
@@ -97,11 +97,20 @@ To run the unit tests, it is recommended that you use the `detox`_ library.
 detox speeds up the tests by running them in parallel.
 
 Install the package with the ``test-runner`` extra to set up the necessary
-dependencies, and then you can run the tests with the ``detox`` command::
+dependencies, and then you can run the tests with the ``tox`` command::
 
   pip install -e .[test-runner]
-  detox -v
+  tox
 
+.. tip::
+  To run tests for multiple Python versions in parallel::
+
+    # Python 3.7 only
+    tox -p all
+
+    # Python 3.6 or earlier
+    pip install detox
+    detox
 
 Documentation
 -------------

--- a/class_registry/registry.py
+++ b/class_registry/registry.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from functools import cmp_to_key
 from inspect import isclass as is_class
 from typing import Any, Callable, Generator, Hashable, Iterator, \
-    Mapping, MutableMapping, Optional, Text, Tuple, Union
+    Optional, Text, Tuple, Union
 
 from six import PY2, iteritems, with_metaclass
 
@@ -30,7 +30,13 @@ class RegistryKeyError(KeyError):
     pass
 
 
-class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
+# This class "should" also derive from Mapping, but this causes a
+# conflict in Python 3.7 because ``with_metaclass()`` creates a type
+# dynamically.
+#
+# See https://bugs.python.org/issue33188 for more information.
+# https://github.com/eflglobal/class-registry/issues/9
+class BaseRegistry(with_metaclass(ABCMeta)):
     """
     Base functionality for registries.
     """
@@ -207,7 +213,13 @@ class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
             return self.values()
 
 
-class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry, MutableMapping)):
+# This class "should" also derive from MutableMapping, but this causes a
+# conflict in Python 3.7 because ``with_metaclass()`` creates a type
+# dynamically.
+#
+# See https://bugs.python.org/issue33188 for more information.
+# https://github.com/eflglobal/class-registry/issues/9
+class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry)):
     """
     Extends :py:class:`BaseRegistry` with methods that can be used to
     modify the registered classes.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
 
     extras_require = {
         'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
-        'test-runner': ['detox'],
+        'test-runner': ['tox'],
     },
 
     test_suite    = 'test',
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Fixes #9 

The issue is caused by a couple of class definitions:

    class BaseRegistry(with_metaclass(ABCMeta, Mapping)):
        ...

    class MutableRegistry(with_metaclass(ABCMeta, BaseRegistry)):
        ...

The error occurs because `with_metaclass()` creates a dynamic type internally, which conflicts when using it with a generic type like `Mapping` and `MutableMapping`.

This issue was discussed on https://bugs.python.org/issue33188 and it appears that the outcome was, "works as intended":

> This is not a bug but an explicit design decision. Generic classes are _static_ typing concept and therefore are not supposed to work freely with _dynamic_ class creation. During discussion of PEP 560 it was decided that there should be at least one way to dynamically create generic classes, `types.new_class` was chosen for this, see https://www.python.org/dev/peps/pep-0560/#dynamic-class-creation-and-types-resolve-bases
> 
> Also the exception message is quite clear about this. Unfortunately, PEPs 560 and 557 were discussed in parallel so not every possible interactions where thought out. But is it critical for dataclasses to call `type`? I believe there should be no other differences with `types.new_class`. I would say the latter is even better than `type` because it correctly treats `__prepare__` on the metaclass IIRC. So I would propose to switch from `type()` to `types.new_class()` for dynamic creation of dataclasses.

There are two possible ways to resolve this issue:

1. Drop support for Python 2 and replace `with_metaclass()` with Python-3-style base/metaclass declarations.
2. Remove the generic types from the `with_metaclass()` invocations.

The downside of approach 2 is that some IDE autocompletion might no longer work.  At this time, this is an acceptable trade-off (especially if the alternative is to drop support for Python 2, which is not something I'm keen to do just yet).